### PR TITLE
Make Plato.NetCore Compatible with Xamarin.Android

### DIFF
--- a/src/Plato/Plato.csproj
+++ b/src/Plato/Plato.csproj
@@ -17,8 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="5.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Autofac" Version="5.2.0" />    
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.5" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />


### PR DESCRIPTION
Remove unused Reference to Microsoft.AspNetCore.Http.Abstractions which breaks linking on Xamarin.Android